### PR TITLE
Fix SQL query for most borrowed books

### DIFF
--- a/src/java/dao/BorrowRecordDao.java
+++ b/src/java/dao/BorrowRecordDao.java
@@ -127,11 +127,10 @@ public class BorrowRecordDao {
     }
 
     public List<Map.Entry<Long, Long>> getMostBorrowedBooks() {
-        String sql = "SELECT book_id, COUNT(*) as borrow_count " +
+        String sql = "SELECT TOP 5 book_id, COUNT(*) AS borrow_count " +
             "FROM borrow_records " +
             "GROUP BY book_id " +
-            "ORDER BY borrow_count DESC " +
-            "LIMIT 5";
+            "ORDER BY borrow_count DESC";
 
         List<Map.Entry<Long, Long>> mostBorrowed = new ArrayList<>();
         try (Connection conn = DbConfig.getConnection();


### PR DESCRIPTION
## Summary
- adjust SQL for `getMostBorrowedBooks` to use `SELECT TOP 5`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684717c0fadc8327a9534f6bad664c23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved compatibility of the "Most Borrowed Books" feature, ensuring the correct top 5 results are displayed regardless of database system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->