### PR TITLE
Add borrowing stats to admin dashboard

### DIFF
--- a/src/java/controller/AdminController.java
+++ b/src/java/controller/AdminController.java
@@ -14,6 +14,7 @@ public class AdminController extends HttpServlet {
     private final BookService bookService = new BookService();
     private final BookRequestService bookRequestService = new BookRequestService();
     private final FineService fineService = new FineService();
+    private final BorrowRecordService borrowRecordService = new BorrowRecordService();
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
@@ -25,6 +26,8 @@ public class AdminController extends HttpServlet {
             request.setAttribute("totalBooks", bookService.getTotalBooks());
             request.setAttribute("pendingRequests", bookRequestService.countPendingRequests());
             request.setAttribute("unpaidFines", fineService.countUnpaidFines());
+            request.setAttribute("borrowedCount", borrowRecordService.countCurrentlyBorrowedBooks());
+            request.setAttribute("mostBorrowedBooks", borrowRecordService.getMostBorrowedBooks());
 
             request.getRequestDispatcher("/admin/layout.jsp").forward(request, response);
         } catch (Exception e) {

--- a/src/java/dao/BorrowRecordDao.java
+++ b/src/java/dao/BorrowRecordDao.java
@@ -126,6 +126,25 @@ public class BorrowRecordDao {
         }
     }
 
+    public long countCurrentlyBorrowed() {
+        String sql = "SELECT COUNT(*) FROM borrow_records WHERE status IN ('BORROWED', 'OVERDUE')";
+
+        try (Connection conn = DbConfig.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql);
+             ResultSet rs = stmt.executeQuery()) {
+
+            if (rs.next()) {
+                return rs.getLong(1);
+            }
+
+        } catch (SQLException e) {
+            LOGGER.log(Level.SEVERE, "Error counting currently borrowed books", e);
+            throw new RuntimeException(e);
+        }
+
+        return 0;
+    }
+
     public List<Map.Entry<Long, Long>> getMostBorrowedBooks() {
         String sql = "SELECT TOP 5 book_id, COUNT(*) AS borrow_count " +
             "FROM borrow_records " +

--- a/src/java/dto/MostBorrowedBookDTO.java
+++ b/src/java/dto/MostBorrowedBookDTO.java
@@ -1,0 +1,39 @@
+package dto;
+
+public class MostBorrowedBookDTO {
+    private long bookId;
+    private String bookTitle;
+    private long borrowCount;
+
+    public MostBorrowedBookDTO() {}
+
+    public MostBorrowedBookDTO(long bookId, String bookTitle, long borrowCount) {
+        this.bookId = bookId;
+        this.bookTitle = bookTitle;
+        this.borrowCount = borrowCount;
+    }
+
+    public long getBookId() {
+        return bookId;
+    }
+
+    public void setBookId(long bookId) {
+        this.bookId = bookId;
+    }
+
+    public String getBookTitle() {
+        return bookTitle;
+    }
+
+    public void setBookTitle(String bookTitle) {
+        this.bookTitle = bookTitle;
+    }
+
+    public long getBorrowCount() {
+        return borrowCount;
+    }
+
+    public void setBorrowCount(long borrowCount) {
+        this.borrowCount = borrowCount;
+    }
+}

--- a/src/java/mapper/BorrowRecordMapping.java
+++ b/src/java/mapper/BorrowRecordMapping.java
@@ -3,6 +3,7 @@ package mapper;
 import dto.*;
 import entity.*;
 import service.*;
+import java.util.Map;
 
 public class BorrowRecordMapping {
     private static final BookService bookService = new BookService();
@@ -29,5 +30,16 @@ public class BorrowRecordMapping {
             record.getReturnDate(),
             record.getStatus() != null ? record.getStatus().toString() : null
         );
+    }
+
+    public static MostBorrowedBookDTO toMostBorrowedBookDTO(Map.Entry<Long, Long> entry) {
+        if (entry == null) {
+            return null;
+        }
+
+        Book book = bookService.getBookById(entry.getKey());
+        String title = book != null ? book.getTitle() : "Unknown Book";
+
+        return new MostBorrowedBookDTO(entry.getKey(), title, entry.getValue());
     }
 }

--- a/src/java/service/BorrowRecordService.java
+++ b/src/java/service/BorrowRecordService.java
@@ -35,4 +35,18 @@ public class BorrowRecordService {
         BorrowRecord record = borrowRecordDao.getById(id);
         return BorrowRecordMapping.toBorrowRecordDTO(record);
     }
+
+    public long countCurrentlyBorrowedBooks() {
+        return borrowRecordDao.countCurrentlyBorrowed();
+    }
+
+    public List<MostBorrowedBookDTO> getMostBorrowedBooks() {
+        List<Map.Entry<Long, Long>> entries = borrowRecordDao.getMostBorrowedBooks();
+        if (entries == null || entries.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return entries.stream()
+            .map(BorrowRecordMapping::toMostBorrowedBookDTO)
+            .collect(Collectors.toList());
+    }
 }

--- a/web/admin/admin.jsp
+++ b/web/admin/admin.jsp
@@ -65,6 +65,32 @@
     </div>
   </div>
 </div>
+
+<!-- Row for borrowed count and top books -->
+<div class="row mt-4">
+  <div class="col-md-3">
+    <div class="card text-white bg-secondary mb-3">
+      <div class="card-header">Currently Borrowed</div>
+      <div class="card-body">
+        <h5 class="card-title">${borrowedCount}</h5>
+        <p class="card-text">Books currently checked out.</p>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-9">
+    <div class="card mb-3">
+      <div class="card-header">Top 5 Most Borrowed Books</div>
+      <ul class="list-group list-group-flush">
+        <c:forEach var="b" items="${mostBorrowedBooks}">
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            ${b.bookTitle}
+            <span class="badge bg-primary rounded-pill">${b.borrowCount}</span>
+          </li>
+        </c:forEach>
+      </ul>
+    </div>
+  </div>
+</div>
         
         <%
             }


### PR DESCRIPTION
## Summary
- provide count of currently borrowed books and top 5 most borrowed
- create `MostBorrowedBookDTO` for book/borrow statistics
- expose new DAO/service/mapping methods to fetch borrow data
- display the new statistics on the admin dashboard using Bootstrap

## Testing
- `ant -version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6847cc0cb4a0832789f1b2c4f2140ad1